### PR TITLE
Add mandatory environment variables

### DIFF
--- a/templates/sample.env
+++ b/templates/sample.env
@@ -4,3 +4,7 @@ APPLICATION_HOST=localhost:3000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node
+SMTP_ADDRESS=smtp.example.com
+SMTP_DOMAIN=example.com
+SMTP_PASSWORD=password
+SMTP_USERNAME=username


### PR DESCRIPTION
If you not set up any environment variables that are accessed using `fetch`, then the deploy to heroku will throw an error. 
That could by quite frustrating because, say, you added `HOST` variable, it thorns an error, then deploy again, and get error about `ASSET_HOST` and so on. 
I think that would be great if list of mandatory environment variables was present in README.
